### PR TITLE
fix unicode strip null bytes

### DIFF
--- a/tnefparse/tnef.py
+++ b/tnefparse/tnef.py
@@ -93,7 +93,7 @@ class TNEFAttachment(object):
             break
 
       if attr is not None:
-         fn = str(attr.data).replace('0','')
+         fn = attr.data[0].strip('\0')
       else:
          fn = self.name
 


### PR DESCRIPTION
Example file in Winmail.dat: UmlautAnhang-äüö.txt

result of long_filename(): `x\\']`

i fixed it with this code change in pull request.

This could be in relation to https://github.com/koodaamo/tnefparse/issues/7